### PR TITLE
systemd service shouldn't fork

### DIFF
--- a/ldm.service
+++ b/ldm.service
@@ -2,9 +2,8 @@
 Description=lightweight device mounter
 
 [Service]
-Type=forking
 EnvironmentFile=/etc/conf.d/ldm
-ExecStart=/usr/bin/ldm -d -u $USER_UID -g $USER_GID
+ExecStart=/usr/bin/ldm -u $USER_UID -g $USER_GID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
No reason for ldm to fork in systemd, fixed.
