### PR TITLE
Fix pod2man build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,18 @@
-CC ?= gcc
-CFLAGS := -O2 $(CFLAGS)
-LDFLAGS := -ludev -lmount $(LDFLAGS)
-CFDEBUG = -g3 -pedantic -Wall -Wunused-parameter -Wlong-long
-CFDEBUG += -Wsign-conversion -Wconversion -Wimplicit-function-declaration
+EXEC = ldm
+VERSION = $(shell grep 'VERSION_STR ' ldm.c | cut -d'"' -f2)
+
+SRCS = ldm.c
+OBJS = $(SRCS:.c=.o)
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 SYSTEMDDIR ?= $(PREFIX)/lib/systemd
 
-EXEC = ldm
-SRCS = ldm.c
-OBJS = $(SRCS:.c=.o)
+CC ?= gcc
+CFLAGS := -O2 $(CFLAGS)
+LDFLAGS := -ludev -lmount $(LDFLAGS)
+CFDEBUG = -g3 -pedantic -Wall -Wunused-parameter -Wlong-long
+CFDEBUG += -Wsign-conversion -Wconversion -Wimplicit-function-declaration
 
 all: $(EXEC) doc
 
@@ -24,7 +26,7 @@ debug: $(EXEC)
 debug: CC += $(CFDEBUG)
 
 doc: README.pod
-	@pod2man --section=1 --center="ldm Manual" --name "ldm" --release="ldm $(shell git describe)" README.pod > ldm.1
+	@pod2man --section=1 --center="ldm Manual" --name "ldm" --release="ldm $(VERSION)" README.pod > ldm.1
 
 clean:
 	$(RM) *.o *.1 ldm

--- a/ldm.c
+++ b/ldm.c
@@ -14,7 +14,7 @@
 #include <libmount/libmount.h>
 #include <errno.h>
 
-#define VERSION_STR "0.4.3"
+#define VERSION_STR "0.5"
 
 enum {
     DEVICE_VOLUME,


### PR DESCRIPTION
When trying to build ldm in a clean chroot/system, the man page is broken:

```
cc -O2 -march=x86-64 -mtune=generic -O2 -pipe -fstack-protector --param=ssp-buffer-size=4 -o ldm.o -c ldm.c
make: git: Command not found
cc -ludev -lmount  -o ldm ldm.o
make: git: Command not found
install -D -m 644 ldm.service /build/ldm/pkg/ldm/usr/lib/systemd/system/ldm.service
install -D -m 755 ldm /build/ldm/pkg/ldm/usr/bin/ldm
install -D -m 644 ldm.1 /build/ldm/pkg/ldm/usr/share/man/man1/ldm.1
```

Add `VERSION` to Makefile.
The version number is now determined using the `VERSION_STR` variable. No more git needed.
Just increasing the variable above automatically raise the version number in the Makefile too.
