### PR TITLE
Canonicalize remove path

### DIFF
--- a/ldm.c
+++ b/ldm.c
@@ -116,7 +116,7 @@ spawn_helper (char *command, char *node, char *action, char *mountpoint)
 
     env_len = 38 + strlen(node) + strlen(action) + strlen(mountpoint);
     env_buf = alloca(env_len + 1);
-    if (!env_buf) 
+    if (!env_buf)
         return 0;
 
     envp[0] = env_buf;
@@ -717,7 +717,7 @@ isdir (const char *path)
 {
     struct stat st;
 
-    if (stat(path, &st) < 0) 
+    if (stat(path, &st) < 0)
         return 0;
 
     return S_ISDIR(st.st_mode);
@@ -747,6 +747,7 @@ main (int argc, char *argv[])
     struct udev_device  *device;
     const  char         *action;
     struct pollfd        pollfd[4];  /* udev / inotify watch / mtab / fifo */
+    char                 rpath[PATH_MAX];
     int                  opt;
     int                  daemon;
     int                  notifyfd;
@@ -767,8 +768,11 @@ main (int argc, char *argv[])
                 if (ipcfd < 0)
                     return EXIT_FAILURE;
 
+                if (!realpath(optarg, rpath))
+                    return EXIT_FAILURE;
+
                 write(ipcfd, "R", 1);
-                write(ipcfd, optarg, strlen(optarg));
+                write(ipcfd, rpath, strlen(rpath));
                 close(ipcfd);
 
                 return EXIT_SUCCESS;


### PR DESCRIPTION
Say that my base folder for the mount points is `/home/mrshankly/mnt`.

Doing this wouldn't work:

```
$ cd /home/mrshankly
$ ldm -r mnt/<device_name>
```

You would have to give the full path `/home/mrshankly/mnt/<device_name>` for it to work.

The patch fixes this.
