### PR TITLE
fix: Mount CDs as read only to avoid breaking mount error.

### DIFF
--- a/ldm.c
+++ b/ldm.c
@@ -482,7 +482,7 @@ device_mount (Device *dev)
 	mnt_context_set_target(ctx, dev->mp);
 	mnt_context_set_options(ctx, opt_fmt);
 
-	if (fs_quirks & RO)
+	if (fs_quirks & RO || udev_get_prop(dev->dev, "ID_CDROM"))
 		mnt_context_set_mflags(ctx, MS_RDONLY);
 
 	if (mnt_context_mount(ctx)) {


### PR DESCRIPTION
This adds the readonly only flag to CDs so they can successfully mount. Related to issue #50.