### PR TITLE
Doesn't compile in ubuntu without link flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ all: ldm ldmc doc
 	$(CC) $(CFLAGS) `pkg-config --cflags $(LIBS)` -o $@ -c $<
 
 ldm: ipc.o ldm.o
-	$(CC) $(LDFLAGS) -o ldm ipc.o ldm.o
+	$(CC) $(LDFLAGS) -o ldm ipc.o ldm.o -ludev -lmount -lglib-2.0
 
 ldmc: ipc.o ldmc.o
 	$(CC) $(LDFLAGS) -o ldmc ipc.o ldmc.o


### PR DESCRIPTION
I'm not very good at compiling things that aren't go, so I'm not sure if these flags are missing or if they are just only required in ubuntu. Without them, ubuntu complains about undefined references. What's the proper way to solve this?