### PR TITLE
fix: Put flags after objects for linker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ all: ldm ldmc doc
 	$(CC) $(CFLAGS) `pkg-config --cflags $(LIBS)` -o $@ -c $<
 
 ldm: ipc.o ldm.o
-	$(CC) $(LDFLAGS) -o ldm ipc.o ldm.o
+	$(CC) -o ldm ipc.o ldm.o $(LDFLAGS)
 
 ldmc: ipc.o ldmc.o
-	$(CC) $(LDFLAGS) -o ldmc ipc.o ldmc.o
+	$(CC) -o ldmc ipc.o ldmc.o $(LDFLAGS)
 
 debug: ldm ldmc
 debug: CC += $(CFDEBUG)


### PR DESCRIPTION
According to the answers on stackoverflow, library flags should go after the objects because the linker resolves references in order.

https://stackoverflow.com/questions/1517138/trying-to-include-a-library-but-keep-getting-undefined-reference-to-messages

This fixes compiling on ubuntu.