### PR TITLE
In some cases it is necessary to do something before an already unplugged device will be unmounted by ldm.

### DIFF
--- a/ldm.c
+++ b/ldm.c
@@ -555,6 +555,8 @@ device_unmount (Device *dev)
 	if (!table_search_by_dev(g_mtab, dev))
 		return 0;
 
+	(void)spawn_callback("pre_unmount", dev);
+
 	ctx = mnt_new_context();
 	mnt_context_set_target(ctx, dev->node);
 

--- a/ldm.pod
+++ b/ldm.pod
@@ -56,7 +56,7 @@ The filesystem on the mounted device.
 
 =item B<LDM_ACTION>
 
-The action ldm has just performed, it can either be I<mount> or I<unmount>
+The action ldm has just performed, it can either be I<mount>, I<pre_unmount> or I<unmount>
 
 =back
 


### PR DESCRIPTION
…gged device will be unmounted by ldm.

For example: NFS clients can hold a file on already unplugged disk on the NFS server on a disk mounted by ldm.
To avoid such situation we have to stop NFS server before unmount.
Otherwise:
Mar 18 12:26:20 myhost ldm[2473]: Error in syscall (Device or resource busy)
Mar 18 12:26:20 myhost ldm[2473]: Error while unmounting /dev/sda1

The idea is to call an already existing command passed in "-c" command line parameter before unmount happens.
LDM_ACTION is set to "pre_unmount".