### PR TITLE
Allow fmask and dmask configuration for systemd unit

### DIFF
--- a/ldm.pod
+++ b/ldm.pod
@@ -82,6 +82,7 @@ The included systemd service expects a config file at /etc/ldm.conf similar to t
 .BB lightgray
 MOUNT_OWNER=\fIusername\fR
 BASE_MOUNTPOINT=\fI/mnt\fR
+FMASK_DMASK=\fIfmask,dmask\fR
 .EB lightgray
 .fi
 .RE
@@ -94,6 +95,7 @@ BASE_MOUNTPOINT=\fI/mnt\fR
 <code>
 MOUNT_OWNER=<i>username</i>
 BASE_MOUNTPOINT=<i>/mnt</i>
+FMASK_DMASK=<i>fmask,dmask</i>
 </code>
 </pre>
 

--- a/ldm.service
+++ b/ldm.service
@@ -2,8 +2,9 @@
 Description=lightweight device mounter
 
 [Service]
+Environment=FMASK_DMASK=0133,0022
 EnvironmentFile=/etc/ldm.conf
-ExecStart=/usr/bin/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT}
+ExecStart=/usr/bin/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT} -m ${FMASK_DMASK}
 KillMode=process
 
 [Install]


### PR DESCRIPTION
Adds optional `FMASK_DMASK` variable to `/etc/ldm.conf`. The value defaults
to `0133,0002` and is passed to the daemon in `-m` parameter