### PR TITLE
Adjust VERSION in Makefile to match most recent tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.6
+VERSION=v0.7
 VERSION_GIT=$(shell test -d .git && git describe 2> /dev/null)
 
 ifneq "$(VERSION_GIT)" ""


### PR DESCRIPTION
While reading the man page, I noticed the version reported there doesn't match the version number indicated by most recent git tag (i.e. v0.7).