### PR TITLE
Add path to command to configurable options

### DIFF
--- a/ldm.pod
+++ b/ldm.pod
@@ -72,7 +72,7 @@ ldm doesn't offer any blacklisting by itself but it honors the options found in 
 
 =head1 INSTALL
 
-The included systemd service expects a config file at /etc/ldm.conf similar to this: 
+The included systemd service expects a config file at /etc/ldm.conf similar to this:
 
 =begin man
 
@@ -83,6 +83,7 @@ The included systemd service expects a config file at /etc/ldm.conf similar to t
 MOUNT_OWNER=\fIusername\fR
 BASE_MOUNTPOINT=\fI/mnt\fR
 FMASK_DMASK=\fIfmask,dmask\fR
+EXTRA_ARGS=\fl-c <path_to_executable>\fR
 .EB lightgray
 .fi
 .RE
@@ -96,10 +97,15 @@ FMASK_DMASK=\fIfmask,dmask\fR
 MOUNT_OWNER=<i>username</i>
 BASE_MOUNTPOINT=<i>/mnt</i>
 FMASK_DMASK=<i>fmask,dmask</i>
+EXTRA_ARGS=<i>-c &lt;path_to_executable&gt;</i>
 </code>
 </pre>
 
 =end html
+
+The options B<FMASK_DMASK> and B<EXTRA_ARGS> are optional.
+The default value for B<FMASK_DMASK> is I<0133,0022>.
+B<EXTRA_ARGS> will be appended to the I<ldm> executable.
 
 =head1 SEE ALSO
 

--- a/ldm.service.in
+++ b/ldm.service.in
@@ -4,7 +4,7 @@ Description=lightweight device mounter
 [Service]
 Environment=FMASK_DMASK=0133,0022
 EnvironmentFile=/etc/ldm.conf
-ExecStart=@@BINDIR@@/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT} -m ${FMASK_DMASK} -c ${COMMAND_PATH}
+ExecStart=@@BINDIR@@/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT} -m ${FMASK_DMASK} ${EXTRA_ARGS}
 KillMode=process
 
 [Install]

--- a/ldm.service.in
+++ b/ldm.service.in
@@ -4,7 +4,7 @@ Description=lightweight device mounter
 [Service]
 Environment=FMASK_DMASK=0133,0022
 EnvironmentFile=/etc/ldm.conf
-ExecStart=@@BINDIR@@/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT} -m ${FMASK_DMASK}
+ExecStart=@@BINDIR@@/ldm -u ${MOUNT_OWNER} -p ${BASE_MOUNTPOINT} -m ${FMASK_DMASK} -c ${COMMAND_PATH}
 KillMode=process
 
 [Install]


### PR DESCRIPTION
This commit makes it a little bit more comfortable to add a custom script for use cases such as in #73.
When the variable is empty/undefined `ldm` simply prints `The callback script isn't executable!` but works fine.
I am unsure about the exact quoting rules in systemd service files.
Maybe the `COMMAND_PATH` should be wrapped in **"** in case of whitespace in path?

Tested this with following config:

/etc/ldm.conf
```sh
MOUNT_OWNER=oli
BASE_MOUNTPOINT=/home/oli/Mounts
FMASK_DMASK=0177,0077
COMMAND_PATH=/etc/ldm_notify.sh
```
/etc/ldm_notify.sh
```sh
#!/bin/sh
env DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/1000/bus /usr/bin/toastify send --icon mount --app-name ldm "$LDM_ACTION" "Mounted $LDM_NODE($LDM_FS) in $LDM_MOUNTPOINT."
```